### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/base-resources.json
+++ b/base-resources.json
@@ -146,7 +146,7 @@
           ]
         },
         "Timeout": 300,
-        "Runtime": "nodejs8.10"
+        "Runtime": "nodejs10.x"
       }
     },
     "SalesForecastLambdaRole": {


### PR DESCRIPTION
CloudFormation templates in amazon-sagemaker-deepar-retail have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.