### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/initialization-template.json
+++ b/initialization-template.json
@@ -97,7 +97,7 @@
         "Handler": "index.handler",
         "MemorySize": 128,
         "Role": { "Fn::GetAtt": [ "CodeInitializerRole", "Arn" ] },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 120
       }
     },
@@ -652,7 +652,7 @@
         "Handler": "index.handler",
         "MemorySize": 128,
         "Role": { "Fn::GetAtt": [ "CloudFormationDeployerFunctionRole", "Arn" ] },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 120
       }
     },


### PR DESCRIPTION
CloudFormation templates in amazon-sagemaker-deepar-retail have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.